### PR TITLE
Fix emoji creation using image buffer instead of URL

### DIFF
--- a/events.js
+++ b/events.js
@@ -491,7 +491,6 @@ async function scrapeLinks(client, eventLinks) {
   fs.writeFileSync('./events.json', JSON.stringify(eventObj));
 } //End of scrapeLinks()
 
-
 async function cronUpdates() {
   let eventEmbeds = await createEmbeds();
   if (eventEmbeds == []) {
@@ -519,7 +518,6 @@ async function cronUpdates() {
     }
   } //End of message loop
 } //End of cronUpdates()
-
 
 //Buttons and Lists
 client.on('interactionCreate', async interaction => {
@@ -569,26 +567,27 @@ client.on('interactionCreate', async interaction => {
   }
 }); //End of buttons/lists
 
-
 async function createEmoji(dexIndex) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      let emojiLink = `https://github.com/RagingRectangle/Pokemojis/blob/main/pokemon/${dexIndex}.gif?raw=true`;
-      await trashServer.emojis.create({
-          attachment: emojiLink,
-          name: dexIndex
-        })
-        .then(emoji => {
-          console.log(`${dexIndex} created: ${emoji.id}`);
-          return resolve(emoji.id);
-        });
-    } catch (err) {
-      console.log(err);
-      return resolve(`ERROR`);
-    }
-  });
-}; //End of createEmoji()
+  try {
+    const emojiLink = `https://raw.githubusercontent.com/RagingRectangle/Pokemojis/main/pokemon/${dexIndex}.gif`;
 
+    const response = await fetch(emojiLink);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const imageBuffer = await response.buffer();
+
+    const emoji = await trashServer.emojis.create({
+      attachment: imageBuffer,
+      name: dexIndex
+    });
+
+    console.log(`${dexIndex} created: ${emoji.id}`);
+    return emoji.id;
+
+  } catch (err) {
+    console.error(`Failed to create emoji for ${dexIndex}:`, err.message);
+    return `ERROR`;
+  }
+}; //End of createEmoji()
 
 async function deleteEmojis(oldEmojis) {
   for (var i in oldEmojis) {


### PR DESCRIPTION
**Description**
This pull request updates the createEmoji function to use node-fetch to download the Pokémon emoji image as a binary buffer before uploading it to the Discord server. This fixes issues where Discord rejected external GitHub URLs as emoji attachments or returned HTTP errors.

**Changes**
- Replaced direct GitHub raw URL usage with a fetch call to retrieve the image buffer.
- Improved error handling and logging.
- Ensures the emoji is uploaded as an actual file, improving compatibility with Discord's API.

**Why?**
Discord does not reliably accept external image URLs (especially those hosted via GitHub's ?raw=true) when creating emojis. This change downloads the image as a buffer and sends it as a file attachment, ensuring consistent behavior.

How to test
Run the bot and trigger the createEmoji(dexIndex) function for various valid dexIndex values (e.g., 1 for Bulbasaur). Check that:
